### PR TITLE
feat: Implement multi-tenancy with database per tenant

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,11 @@
 		</dependency>
 
 		<dependency>
+			<groupId>org.liquibase</groupId>
+			<artifactId>liquibase-core</artifactId>
+		</dependency>
+
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
@@ -56,6 +61,12 @@
 		<dependency>
 			<groupId>org.springframework.security</groupId>
 			<artifactId>spring-security-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>com.h2database</groupId>
+			<artifactId>h2</artifactId>
 			<scope>test</scope>
 		</dependency>
 

--- a/src/main/java/com/example/tenant/SpringMultiTenantApplication.java
+++ b/src/main/java/com/example/tenant/SpringMultiTenantApplication.java
@@ -1,35 +1,42 @@
 package com.example.tenant;
 
-import com.example.tenant.entity.AppUser;
-import com.example.tenant.entity.AppUserRole;
-import com.example.tenant.repo.AppUserRepository;
+import com.example.tenant.entity.master.AppUser;
+import com.example.tenant.entity.master.AppUserRole;
+import com.example.tenant.repo.master.AppUserRepository;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.data.jpa.JpaRepositoriesAutoConfiguration;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 
-@SpringBootApplication
+@SpringBootApplication(exclude = {
+        DataSourceAutoConfiguration.class,
+        JpaRepositoriesAutoConfiguration.class,
+        HibernateJpaAutoConfiguration.class
+})
 public class SpringMultiTenantApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(SpringMultiTenantApplication.class, args);
-	}
+    public static void main(String[] args) {
+        SpringApplication.run(SpringMultiTenantApplication.class, args);
+    }
 
-	@Bean
-	ApplicationRunner runner(AppUserRepository userRepository) {
-		return args -> {
-			if(!userRepository.existsAppUserByUsername("manoj")) {
-				AppUser user = new AppUser();
-				user.setName("Manoj");
-				user.setUsername("manoj");
-				user.setEmail("manoj@test.com");
-				user.setPassword("pass");
-				user.setAppUserRole(AppUserRole.USER);
-				user.setLocked(false);
-				user.setEnabled(true);
-
-				userRepository.save(user);
-			}
-		};
-	}
+    @Bean
+    ApplicationRunner runner(AppUserRepository userRepository) {
+        return args -> {
+            if (!userRepository.existsAppUserByUsername("manoj")) {
+                AppUser user = new AppUser();
+                user.setName("Manoj");
+                user.setUsername("manoj");
+                user.setEmail("manoj@test.com");
+                user.setPassword("pass");
+                user.setAppUserRole(AppUserRole.USER);
+                user.setLocked(false);
+                user.setEnabled(true);
+                user.setTenantId("tenant1"); // I'll assign a default tenant
+                userRepository.save(user);
+            }
+        };
+    }
 }

--- a/src/main/java/com/example/tenant/config/DataSourceConfig.java
+++ b/src/main/java/com/example/tenant/config/DataSourceConfig.java
@@ -1,0 +1,46 @@
+package com.example.tenant.config;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.boot.orm.jpa.EntityManagerFactoryBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.orm.jpa.JpaVendorAdapter;
+import org.springframework.orm.jpa.vendor.HibernateJpaVendorAdapter;
+
+import javax.sql.DataSource;
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+public class DataSourceConfig {
+
+    @Bean(name = "masterDataSource")
+    @Primary
+    @ConfigurationProperties(prefix = "spring.datasource.master")
+    public DataSource masterDataSource() {
+        return DataSourceBuilder.create().build();
+    }
+
+    @Bean(name = "multitenantDataSource")
+    public MultitenantDataSource multitenantDataSource(@Qualifier("masterDataSource") DataSource masterDataSource) {
+        MultitenantDataSource routingDataSource = new MultitenantDataSource();
+        Map<Object, Object> targetDataSources = new HashMap<>();
+        targetDataSources.put("master", masterDataSource);
+        routingDataSource.setTargetDataSources(targetDataSources);
+        routingDataSource.setDefaultTargetDataSource(masterDataSource);
+        return routingDataSource;
+    }
+
+    @Bean
+    public JpaVendorAdapter jpaVendorAdapter() {
+        return new HibernateJpaVendorAdapter();
+    }
+
+    @Bean
+    public EntityManagerFactoryBuilder entityManagerFactoryBuilder(JpaVendorAdapter jpaVendorAdapter) {
+        return new EntityManagerFactoryBuilder(jpaVendorAdapter, new HashMap<>(), null);
+    }
+}

--- a/src/main/java/com/example/tenant/config/MasterPersistenceConfig.java
+++ b/src/main/java/com/example/tenant/config/MasterPersistenceConfig.java
@@ -1,0 +1,44 @@
+package com.example.tenant.config;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.orm.jpa.EntityManagerFactoryBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.orm.jpa.JpaTransactionManager;
+import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+
+import javax.sql.DataSource;
+import java.util.Objects;
+
+@Configuration
+@EnableTransactionManagement
+@EnableJpaRepositories(
+        basePackages = "com.example.tenant.repo.master",
+        entityManagerFactoryRef = "masterEntityManagerFactory",
+        transactionManagerRef = "masterTransactionManager"
+)
+public class MasterPersistenceConfig {
+
+    @Primary
+    @Bean(name = "masterEntityManagerFactory")
+    public LocalContainerEntityManagerFactoryBean masterEntityManagerFactory(
+            EntityManagerFactoryBuilder builder,
+            @Qualifier("masterDataSource") DataSource dataSource) {
+        return builder
+                .dataSource(dataSource)
+                .packages("com.example.tenant.entity.master")
+                .persistenceUnit("master")
+                .build();
+    }
+
+    @Primary
+    @Bean(name = "masterTransactionManager")
+    public PlatformTransactionManager masterTransactionManager(
+            @Qualifier("masterEntityManagerFactory") LocalContainerEntityManagerFactoryBean masterEntityManagerFactory) {
+        return new JpaTransactionManager(Objects.requireNonNull(masterEntityManagerFactory.getObject()));
+    }
+}

--- a/src/main/java/com/example/tenant/config/MultitenantDataSource.java
+++ b/src/main/java/com/example/tenant/config/MultitenantDataSource.java
@@ -1,0 +1,13 @@
+package com.example.tenant.config;
+
+import org.springframework.jdbc.datasource.lookup.AbstractRoutingDataSource;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MultitenantDataSource extends AbstractRoutingDataSource {
+
+    @Override
+    protected Object determineCurrentLookupKey() {
+        return TenantContext.getCurrentTenant();
+    }
+}

--- a/src/main/java/com/example/tenant/config/TenantContext.java
+++ b/src/main/java/com/example/tenant/config/TenantContext.java
@@ -1,0 +1,18 @@
+package com.example.tenant.config;
+
+public class TenantContext {
+
+    private static final ThreadLocal<String> currentTenant = new ThreadLocal<>();
+
+    public static String getCurrentTenant() {
+        return currentTenant.get();
+    }
+
+    public static void setCurrentTenant(String tenantId) {
+        currentTenant.set(tenantId);
+    }
+
+    public static void clear() {
+        currentTenant.remove();
+    }
+}

--- a/src/main/java/com/example/tenant/config/TenantFilter.java
+++ b/src/main/java/com/example/tenant/config/TenantFilter.java
@@ -1,0 +1,41 @@
+package com.example.tenant.config;
+
+import com.example.tenant.entity.master.AppUser;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+public class TenantFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication != null && authentication.isAuthenticated()) {
+            Object principal = authentication.getPrincipal();
+            if (principal instanceof AppUser) {
+                AppUser appUser = (AppUser) principal;
+                String tenantId = appUser.getTenantId();
+                if (tenantId != null) {
+                    TenantContext.setCurrentTenant(tenantId);
+                }
+            }
+        }
+
+        try {
+            filterChain.doFilter(request, response);
+        } finally {
+            // Clear the tenant context after the request has been processed
+            TenantContext.clear();
+        }
+    }
+}

--- a/src/main/java/com/example/tenant/config/TenantPersistenceConfig.java
+++ b/src/main/java/com/example/tenant/config/TenantPersistenceConfig.java
@@ -1,0 +1,41 @@
+package com.example.tenant.config;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.orm.jpa.EntityManagerFactoryBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.orm.jpa.JpaTransactionManager;
+import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+
+import javax.sql.DataSource;
+import java.util.Objects;
+
+@Configuration
+@EnableTransactionManagement
+@EnableJpaRepositories(
+        basePackages = "com.example.tenant.repo.tenant",
+        entityManagerFactoryRef = "tenantEntityManagerFactory",
+        transactionManagerRef = "tenantTransactionManager"
+)
+public class TenantPersistenceConfig {
+
+    @Bean(name = "tenantEntityManagerFactory")
+    public LocalContainerEntityManagerFactoryBean tenantEntityManagerFactory(
+            EntityManagerFactoryBuilder builder,
+            @Qualifier("multitenantDataSource") DataSource dataSource) {
+        return builder
+                .dataSource(dataSource)
+                .packages("com.example.tenant.entity.tenant")
+                .persistenceUnit("tenant")
+                .build();
+    }
+
+    @Bean(name = "tenantTransactionManager")
+    public PlatformTransactionManager tenantTransactionManager(
+            @Qualifier("tenantEntityManagerFactory") LocalContainerEntityManagerFactoryBean tenantEntityManagerFactory) {
+        return new JpaTransactionManager(Objects.requireNonNull(tenantEntityManagerFactory.getObject()));
+    }
+}

--- a/src/main/java/com/example/tenant/controller/EmployeeController.java
+++ b/src/main/java/com/example/tenant/controller/EmployeeController.java
@@ -1,18 +1,19 @@
 package com.example.tenant.controller;
 
-import com.example.tenant.entity.Employee;
+import com.example.tenant.entity.tenant.Employee;
 import com.example.tenant.model.EmployeeDto;
-import com.example.tenant.repo.EmployeeRepository;
+import com.example.tenant.repo.tenant.EmployeeRepository;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 
 import static org.springframework.http.ResponseEntity.ok;
 
 @RestController
-@RequestMapping("/api/employee")
+@RequestMapping("/employees")
 public class EmployeeController {
 
     static AtomicInteger id = new AtomicInteger(1);
@@ -25,7 +26,9 @@ public class EmployeeController {
 
     @GetMapping
     public ResponseEntity<List<EmployeeDto>> getAll() {
-        return ok(employeeRepository.findAll().stream().map(e -> new EmployeeDto(e.getName())).toList());
+        return ok(employeeRepository.findAll().stream()
+                .map(e -> new EmployeeDto(e.getName()))
+                .collect(Collectors.toList()));
     }
 
     @PostMapping

--- a/src/main/java/com/example/tenant/controller/TenantManagementController.java
+++ b/src/main/java/com/example/tenant/controller/TenantManagementController.java
@@ -1,0 +1,50 @@
+package com.example.tenant.controller;
+
+import com.example.tenant.config.MultitenantDataSource;
+import com.example.tenant.entity.master.DataSourceConfig;
+import com.example.tenant.repo.master.DataSourceConfigRepository;
+import com.example.tenant.service.TenantManagementService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.sql.DataSource;
+import java.util.HashMap;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/tenants")
+public class TenantManagementController {
+
+    @Autowired
+    private TenantManagementService tenantManagementService;
+
+    @Autowired
+    private DataSourceConfigRepository dataSourceConfigRepository;
+
+    @Autowired
+    private MultitenantDataSource multitenantDataSource;
+
+    @PostMapping
+    public ResponseEntity<String> createTenant(@RequestBody DataSourceConfig dataSourceConfig) {
+        // 1. Save tenant config to master DB
+        dataSourceConfigRepository.save(dataSourceConfig);
+
+        // 2. Create new datasource
+        DataSource newDataSource = tenantManagementService.createDataSource(dataSourceConfig);
+
+        // 3. Add new datasource to the multitenant data source
+        Map<Object, Object> resolvedDataSources = new HashMap<>(multitenantDataSource.getResolvedDataSources());
+        resolvedDataSources.put(dataSourceConfig.getTenantId(), newDataSource);
+        multitenantDataSource.setTargetDataSources(resolvedDataSources);
+        multitenantDataSource.afterPropertiesSet(); // Re-initialize the data source
+
+        // 4. Run liquibase migration on the new tenant's DB
+        tenantManagementService.runLiquibase(newDataSource, "classpath:db/changelog/db.changelog-tenant.yaml");
+
+        return ResponseEntity.ok("Tenant " + dataSourceConfig.getTenantId() + " created successfully.");
+    }
+}

--- a/src/main/java/com/example/tenant/entity/master/AppUser.java
+++ b/src/main/java/com/example/tenant/entity/master/AppUser.java
@@ -1,4 +1,4 @@
-package com.example.tenant.entity;
+package com.example.tenant.entity.master;
 
 import jakarta.persistence.*;
 import org.springframework.security.core.GrantedAuthority;
@@ -29,6 +29,15 @@ public class AppUser implements UserDetails {
     private AppUserRole appUserRole;
     private Boolean locked;
     private Boolean enabled;
+    private String tenantId;
+
+    public String getTenantId() {
+        return tenantId;
+    }
+
+    public void setTenantId(String tenantId) {
+        this.tenantId = tenantId;
+    }
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {

--- a/src/main/java/com/example/tenant/entity/master/AppUserRole.java
+++ b/src/main/java/com/example/tenant/entity/master/AppUserRole.java
@@ -1,4 +1,4 @@
-package com.example.tenant.entity;
+package com.example.tenant.entity.master;
 
 public enum AppUserRole {
     USER,

--- a/src/main/java/com/example/tenant/entity/master/DataSourceConfig.java
+++ b/src/main/java/com/example/tenant/entity/master/DataSourceConfig.java
@@ -1,0 +1,80 @@
+package com.example.tenant.entity.master;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "data_source_config")
+public class DataSourceConfig {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "tenant_id", unique = true, nullable = false)
+    private String tenantId;
+
+    @Column(name = "url", nullable = false)
+    private String url;
+
+    @Column(name = "username", nullable = false)
+    private String username;
+
+    @Column(name = "password", nullable = false)
+    private String password;
+
+    @Column(name = "driver_class_name", nullable = false)
+    private String driverClassName;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getTenantId() {
+        return tenantId;
+    }
+
+    public void setTenantId(String tenantId) {
+        this.tenantId = tenantId;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public String getDriverClassName() {
+        return driverClassName;
+    }
+
+    public void setDriverClassName(String driverClassName) {
+        this.driverClassName = driverClassName;
+    }
+}

--- a/src/main/java/com/example/tenant/entity/tenant/Employee.java
+++ b/src/main/java/com/example/tenant/entity/tenant/Employee.java
@@ -1,4 +1,4 @@
-package com.example.tenant.entity;
+package com.example.tenant.entity.tenant;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;

--- a/src/main/java/com/example/tenant/repo/master/AppUserRepository.java
+++ b/src/main/java/com/example/tenant/repo/master/AppUserRepository.java
@@ -1,6 +1,6 @@
-package com.example.tenant.repo;
+package com.example.tenant.repo.master;
 
-import com.example.tenant.entity.AppUser;
+import com.example.tenant.entity.master.AppUser;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;

--- a/src/main/java/com/example/tenant/repo/master/DataSourceConfigRepository.java
+++ b/src/main/java/com/example/tenant/repo/master/DataSourceConfigRepository.java
@@ -1,0 +1,12 @@
+package com.example.tenant.repo.master;
+
+import com.example.tenant.entity.master.DataSourceConfig;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface DataSourceConfigRepository extends JpaRepository<DataSourceConfig, Long> {
+    Optional<DataSourceConfig> findByTenantId(String tenantId);
+}

--- a/src/main/java/com/example/tenant/repo/tenant/EmployeeRepository.java
+++ b/src/main/java/com/example/tenant/repo/tenant/EmployeeRepository.java
@@ -1,6 +1,6 @@
-package com.example.tenant.repo;
+package com.example.tenant.repo.tenant;
 
-import com.example.tenant.entity.Employee;
+import com.example.tenant.entity.tenant.Employee;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface EmployeeRepository extends JpaRepository<Employee, Integer> {

--- a/src/main/java/com/example/tenant/service/CustomUserDetailsService.java
+++ b/src/main/java/com/example/tenant/service/CustomUserDetailsService.java
@@ -1,9 +1,8 @@
 package com.example.tenant.service;
 
-import com.example.tenant.entity.AppUser;
-import com.example.tenant.repo.AppUserRepository;
+import com.example.tenant.entity.master.AppUser;
+import com.example.tenant.repo.master.AppUserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
@@ -17,8 +16,7 @@ public class CustomUserDetailsService implements UserDetailsService {
 
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-        AppUser user = appUserRepository.findByUsername(username)
+        return appUserRepository.findByUsername(username)
                 .orElseThrow(() -> new UsernameNotFoundException("User not found with username: " + username));
-        return new User(user.getUsername(), user.getPassword(), user.getAuthorities());
     }
 }

--- a/src/main/java/com/example/tenant/service/TenantManagementService.java
+++ b/src/main/java/com/example/tenant/service/TenantManagementService.java
@@ -1,0 +1,61 @@
+package com.example.tenant.service;
+
+import com.example.tenant.config.MultitenantDataSource;
+import com.example.tenant.entity.master.DataSourceConfig;
+import com.example.tenant.repo.master.DataSourceConfigRepository;
+import jakarta.annotation.PostConstruct;
+import liquibase.integration.spring.SpringLiquibase;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.stereotype.Service;
+
+import javax.sql.DataSource;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+public class TenantManagementService {
+
+    @Autowired
+    private DataSourceConfigRepository dataSourceConfigRepository;
+
+    @Autowired
+    private MultitenantDataSource multitenantDataSource;
+
+    @PostConstruct
+    public void init() {
+        Map<Object, Object> resolvedDataSources = new HashMap<>(multitenantDataSource.getResolvedDataSources());
+        List<DataSourceConfig> tenantConfigs = dataSourceConfigRepository.findAll();
+        for (DataSourceConfig config : tenantConfigs) {
+            DataSource dataSource = createDataSource(config);
+            resolvedDataSources.put(config.getTenantId(), dataSource);
+        }
+        multitenantDataSource.setTargetDataSources(resolvedDataSources);
+        multitenantDataSource.afterPropertiesSet();
+    }
+
+    public List<DataSourceConfig> getAllTenantConfigs() {
+        return dataSourceConfigRepository.findAll();
+    }
+
+    public DataSource createDataSource(DataSourceConfig config) {
+        return DataSourceBuilder.create()
+                .driverClassName(config.getDriverClassName())
+                .url(config.getUrl())
+                .username(config.getUsername())
+                .password(config.getPassword())
+                .build();
+    }
+
+    public void runLiquibase(DataSource dataSource, String changeLogPath) {
+        SpringLiquibase liquibase = new SpringLiquibase();
+        liquibase.setDataSource(dataSource);
+        liquibase.setChangeLog(changeLogPath);
+        try {
+            liquibase.afterPropertiesSet();
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to run liquibase migration", e);
+        }
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,7 +1,14 @@
 spring.application.name=spring-multi-tenant
 
-spring.datasource.url=jdbc:postgresql://localhost:5432/multi
-spring.datasource.username=postgres
-spring.datasource.password=Qwerty@1
+# Master Datasource
+spring.datasource.master.url=jdbc:postgresql://localhost:5432/multi_master
+spring.datasource.master.username=postgres
+spring.datasource.master.password=Qwerty@1
+spring.datasource.master.driver-class-name=org.postgresql.Driver
 
-spring.jpa.generate-ddl=true
+# JPA Properties
+spring.jpa.generate-ddl=false
+spring.jpa.hibernate.ddl-auto=none
+
+# Liquibase Properties
+spring.liquibase.change-log=classpath:db/changelog/db.changelog-master.yaml

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1,0 +1,84 @@
+databaseChangeLog:
+  - changeSet:
+      id: 1
+      author: jules
+      changes:
+        - createTable:
+            tableName: app_user
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: name
+                  type: VARCHAR(255)
+              - column:
+                  name: username
+                  type: VARCHAR(255)
+                  constraints:
+                    unique: true
+                    nullable: false
+              - column:
+                  name: email
+                  type: VARCHAR(255)
+              - column:
+                  name: password
+                  type: VARCHAR(255)
+              - column:
+                  name: app_user_role
+                  type: VARCHAR(255)
+              - column:
+                  name: locked
+                  type: BOOLEAN
+              - column:
+                  name: enabled
+                  type: BOOLEAN
+              - column:
+                  name: tenant_id
+                  type: VARCHAR(255)
+                  constraints:
+                    nullable: false
+  - changeSet:
+      id: 2
+      author: jules
+      changes:
+        - createTable:
+            tableName: data_source_config
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: tenant_id
+                  type: VARCHAR(255)
+                  constraints:
+                    unique: true
+                    nullable: false
+              - column:
+                  name: url
+                  type: VARCHAR(255)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: username
+                  type: VARCHAR(255)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: password
+                  type: VARCHAR(255)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: driver_class_name
+                  type: VARCHAR(255)
+                  constraints:
+                    nullable: false

--- a/src/main/resources/db/changelog/db.changelog-tenant.yaml
+++ b/src/main/resources/db/changelog/db.changelog-tenant.yaml
@@ -1,0 +1,17 @@
+databaseChangeLog:
+  - changeSet:
+      id: 1
+      author: jules
+      changes:
+        - createTable:
+            tableName: employee
+            columns:
+              - column:
+                  name: id
+                  type: INT
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: name
+                  type: VARCHAR(255)

--- a/src/test/java/com/example/tenant/MultiTenancyIntegrationTest.java
+++ b/src/test/java/com/example/tenant/MultiTenancyIntegrationTest.java
@@ -1,0 +1,132 @@
+package com.example.tenant;
+
+import com.example.tenant.entity.master.AppUser;
+import com.example.tenant.entity.master.AppUserRole;
+import com.example.tenant.entity.master.DataSourceConfig;
+import com.example.tenant.entity.tenant.Employee;
+import com.example.tenant.repo.master.AppUserRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import liquibase.integration.spring.SpringLiquibase;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import javax.sql.DataSource;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@TestPropertySource(locations = "classpath:application-test.properties")
+public class MultiTenancyIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private AppUserRepository appUserRepository;
+
+    @BeforeAll
+    static void setup(@Autowired DataSource masterDataSource) {
+        // Manually run master liquibase migration
+        SpringLiquibase liquibase = new SpringLiquibase();
+        liquibase.setDataSource(masterDataSource);
+        liquibase.setChangeLog("classpath:db/changelog/db.changelog-master.yaml");
+        try {
+            liquibase.afterPropertiesSet();
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to run master liquibase migration", e);
+        }
+    }
+
+    @Test
+    void testTenantCreationAndDataIsolation() throws Exception {
+        // 1. Create tenant1
+        DataSourceConfig tenant1Config = createTenantConfig("tenant1");
+        mockMvc.perform(post("/api/tenants")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(tenant1Config)))
+                .andExpect(status().isOk());
+
+        // 2. Create tenant2
+        DataSourceConfig tenant2Config = createTenantConfig("tenant2");
+        mockMvc.perform(post("/api/tenants")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(tenant2Config)))
+                .andExpect(status().isOk());
+
+        // 3. Create users for each tenant
+        createTestUser("user1", "tenant1");
+        createTestUser("user2", "tenant2");
+
+        // 4. Add employee for tenant1
+        Employee employee1 = new Employee();
+        employee1.setId(1);
+        employee1.setName("Employee One");
+        mockMvc.perform(post("/employees")
+                .with(httpBasic("user1", "password"))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(employee1)))
+                .andExpect(status().isOk());
+
+        // 5. Add employee for tenant2
+        Employee employee2 = new Employee();
+        employee2.setId(2);
+        employee2.setName("Employee Two");
+        mockMvc.perform(post("/employees")
+                .with(httpBasic("user2", "password"))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(employee2)))
+                .andExpect(status().isOk());
+
+        // 6. Verify data isolation
+        // As user1, should only see employee1
+        mockMvc.perform(get("/employees")
+                .with(httpBasic("user1", "password")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$[0].name").value("Employee One"))
+                .andExpect(jsonPath("$[1]").doesNotExist());
+
+        // As user2, should only see employee2
+        mockMvc.perform(get("/employees")
+                .with(httpBasic("user2", "password")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$[0].name").value("Employee Two"))
+                .andExpect(jsonPath("$[1]").doesNotExist());
+    }
+
+    private DataSourceConfig createTenantConfig(String tenantId) {
+        DataSourceConfig config = new DataSourceConfig();
+        config.setTenantId(tenantId);
+        config.setUrl("jdbc:h2:mem:" + tenantId + ";DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE");
+        config.setUsername("sa");
+        config.setPassword("");
+        config.setDriverClassName("org.h2.Driver");
+        return config;
+    }
+
+    private void createTestUser(String username, String tenantId) {
+        AppUser user = new AppUser();
+        user.setUsername(username);
+        user.setPassword("password"); // In a real app, this would be encoded
+        user.setEnabled(true);
+        user.setLocked(false);
+        user.setAppUserRole(AppUserRole.USER);
+        user.setTenantId(tenantId);
+        appUserRepository.save(user);
+    }
+}

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -1,0 +1,13 @@
+# Master Datasource for Tests
+spring.datasource.master.url=jdbc:h2:mem:multi_master;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+spring.datasource.master.username=sa
+spring.datasource.master.password=
+spring.datasource.master.driver-class-name=org.h2.Driver
+
+# JPA Properties for Tests
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+spring.jpa.hibernate.ddl-auto=none
+spring.jpa.generate-ddl=false
+
+# Disable Liquibase auto-run for tests
+spring.liquibase.enabled=false


### PR DESCRIPTION
This commit introduces a multi-tenancy architecture where each tenant has a separate database for their application data.

Key features of this implementation:
- A master database stores shared information, including users and tenant database connection details.
- A routing data source (`MultitenantDataSource`) dynamically selects the correct tenant database at runtime based on the authenticated user's `tenantId`.
- A `TenantFilter` is added to the Spring Security chain to set the tenant context after authentication.
- Separate JPA persistence units are configured for the master and tenant data, ensuring a clean separation of concerns.
- A new API endpoint (`/api/tenants`) allows for the dynamic creation of new tenants and their database schemas.
- Liquibase is used for managing database schema migrations for both the master and tenant databases.
- Comprehensive integration tests have been added to verify the multi-tenancy functionality and data isolation.