### PR TITLE
feat: Add async task with tenant context propagation

### DIFF
--- a/src/main/java/com/example/tenant/SpringMultiTenantApplication.java
+++ b/src/main/java/com/example/tenant/SpringMultiTenantApplication.java
@@ -11,8 +11,10 @@ import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.autoconfigure.liquibase.LiquibaseAutoConfiguration;
 import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
 import org.springframework.context.annotation.Bean;
+import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
+@EnableAsync
 @SpringBootApplication(exclude = {
         DataSourceAutoConfiguration.class,
         JpaRepositoriesAutoConfiguration.class,

--- a/src/main/java/com/example/tenant/config/AsyncConfig.java
+++ b/src/main/java/com/example/tenant/config/AsyncConfig.java
@@ -1,0 +1,23 @@
+package com.example.tenant.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+@Configuration
+public class AsyncConfig {
+
+    @Bean(name = "taskExecutor")
+    public Executor taskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(5);
+        executor.setMaxPoolSize(10);
+        executor.setQueueCapacity(25);
+        executor.setThreadNamePrefix("Async-");
+        executor.setTaskDecorator(new TenantAwareTaskDecorator());
+        executor.initialize();
+        return executor;
+    }
+}

--- a/src/main/java/com/example/tenant/config/TenantAwareTaskDecorator.java
+++ b/src/main/java/com/example/tenant/config/TenantAwareTaskDecorator.java
@@ -1,0 +1,21 @@
+package com.example.tenant.config;
+
+import org.springframework.core.task.TaskDecorator;
+import org.springframework.lang.NonNull;
+
+public class TenantAwareTaskDecorator implements TaskDecorator {
+
+    @Override
+    @NonNull
+    public Runnable decorate(@NonNull Runnable runnable) {
+        String tenantId = TenantContext.getCurrentTenant();
+        return () -> {
+            try {
+                TenantContext.setCurrentTenant(tenantId);
+                runnable.run();
+            } finally {
+                TenantContext.clear();
+            }
+        };
+    }
+}

--- a/src/main/java/com/example/tenant/controller/EmployeeController.java
+++ b/src/main/java/com/example/tenant/controller/EmployeeController.java
@@ -3,10 +3,12 @@ package com.example.tenant.controller;
 import com.example.tenant.entity.tenant.Employee;
 import com.example.tenant.model.EmployeeDto;
 import com.example.tenant.repo.tenant.EmployeeRepository;
+import com.example.tenant.service.AsyncService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 
 import static org.springframework.http.ResponseEntity.ok;
@@ -16,9 +18,21 @@ import static org.springframework.http.ResponseEntity.ok;
 public class EmployeeController {
 
     private final EmployeeRepository employeeRepository;
+    private final AsyncService asyncService;
 
-    public EmployeeController(EmployeeRepository employeeRepository) {
+    public EmployeeController(EmployeeRepository employeeRepository, AsyncService asyncService) {
         this.employeeRepository = employeeRepository;
+        this.asyncService = asyncService;
+    }
+
+    @PostMapping("/async")
+    public ResponseEntity<EmployeeDto> createAsync(@RequestBody EmployeeDto employeeDto) throws ExecutionException, InterruptedException {
+        Employee employee = new Employee();
+        employee.setName(employeeDto.getName());
+        employee = asyncService.saveEmployee(employee).get();
+
+        employeeDto.setId(employee.getId());
+        return ok(employeeDto);
     }
 
     @GetMapping

--- a/src/main/java/com/example/tenant/repo/master/AppUserRepository.java
+++ b/src/main/java/com/example/tenant/repo/master/AppUserRepository.java
@@ -3,10 +3,15 @@ package com.example.tenant.repo.master;
 import com.example.tenant.entity.master.AppUser;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import org.springframework.transaction.annotation.Transactional;
+
 import java.util.Optional;
 
 public interface AppUserRepository extends JpaRepository<AppUser, Long> {
     Optional<AppUser> findByEmail(String email);
 
     boolean existsAppUserByEmail(String email);
+
+    @Transactional
+    void deleteByTenantId(String tenantId);
 }

--- a/src/main/java/com/example/tenant/repo/master/TenantConfigRepository.java
+++ b/src/main/java/com/example/tenant/repo/master/TenantConfigRepository.java
@@ -3,10 +3,14 @@ package com.example.tenant.repo.master;
 import com.example.tenant.entity.master.TenantConfig;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
 @Repository
 public interface TenantConfigRepository extends JpaRepository<TenantConfig, Long> {
     Optional<TenantConfig> findByTenantId(String tenantId);
+
+    @Transactional
+    void deleteByTenantId(String tenantId);
 }

--- a/src/main/java/com/example/tenant/service/AsyncService.java
+++ b/src/main/java/com/example/tenant/service/AsyncService.java
@@ -1,0 +1,22 @@
+package com.example.tenant.service;
+
+import com.example.tenant.entity.tenant.Employee;
+import com.example.tenant.repo.tenant.EmployeeRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.CompletableFuture;
+
+@Service
+public class AsyncService {
+
+    @Autowired
+    private EmployeeRepository employeeRepository;
+
+    @Async
+    public CompletableFuture<Employee> saveEmployee(Employee employee) {
+        Employee savedEmployee = employeeRepository.save(employee);
+        return CompletableFuture.completedFuture(savedEmployee);
+    }
+}

--- a/src/test/java/com/example/tenant/AsyncTenantContextTest.java
+++ b/src/test/java/com/example/tenant/AsyncTenantContextTest.java
@@ -1,0 +1,210 @@
+package com.example.tenant;
+
+import com.example.tenant.entity.master.TenantConfig;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.json.JSONObject;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import com.example.tenant.repo.master.AppUserRepository;
+import com.example.tenant.repo.master.TenantConfigRepository;
+import org.junit.jupiter.api.AfterAll;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+class AsyncTenantContextTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private static TenantConfigRepository tenantConfigRepository;
+
+    private static AppUserRepository appUserRepository;
+
+    @Autowired
+    void setTenantConfigRepository(TenantConfigRepository tenantConfigRepository) {
+        AsyncTenantContextTest.tenantConfigRepository = tenantConfigRepository;
+    }
+
+    @Autowired
+    void setAppUserRepository(AppUserRepository appUserRepository) {
+        AsyncTenantContextTest.appUserRepository = appUserRepository;
+    }
+
+    private static String adminAuthToken;
+    private static String tenant1AuthToken;
+    private static String tenant2AuthToken;
+
+    @Test
+    @Order(1)
+    void adminLogin() throws Exception {
+        JSONObject credentials = new JSONObject();
+        credentials.put("username", "admin@test.com");
+        credentials.put("password", "pass");
+
+        MvcResult mvcResult = mockMvc.perform(post("/api/security/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(credentials.toString()))
+                .andExpect(status().isOk())
+                .andReturn();
+        JsonNode jsonNode = objectMapper.readTree(mvcResult.getResponse().getContentAsString());
+        adminAuthToken = "Bearer " + jsonNode.get("accessToken").asText();
+    }
+
+    @Test
+    @Order(2)
+    void createTenants() throws Exception {
+        TenantConfig tenant1Config = createTenantConfig("tenant3");
+        mockMvc.perform(post("/api/tenants")
+                        .header(HttpHeaders.AUTHORIZATION, adminAuthToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(tenant1Config)))
+                .andExpect(status().isOk());
+
+        TenantConfig tenant2Config = createTenantConfig("tenant4");
+        mockMvc.perform(post("/api/tenants")
+                        .header(HttpHeaders.AUTHORIZATION, adminAuthToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(tenant2Config)))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @Order(3)
+    void createAppUsersForTenants() throws Exception {
+        JSONObject user1 = new JSONObject();
+        user1.put("name", "user3");
+        user1.put("tenantId", "tenant3");
+        user1.put("email", "user3@test.com");
+        user1.put("password", "pass");
+
+        mockMvc.perform(post("/api/security/users")
+                        .header(HttpHeaders.AUTHORIZATION, adminAuthToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(user1.toString()))
+                .andExpect(status().isOk());
+
+        JSONObject user2 = new JSONObject();
+        user2.put("name", "user4");
+        user2.put("tenantId", "tenant4");
+        user2.put("email", "user4@test.com");
+        user2.put("password", "pass");
+
+        mockMvc.perform(post("/api/security/users")
+                        .header(HttpHeaders.AUTHORIZATION, adminAuthToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(user2.toString()))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @Order(4)
+    void loginTenants() throws Exception {
+        JSONObject credentials1 = new JSONObject();
+        credentials1.put("username", "user3@test.com");
+        credentials1.put("password", "pass");
+
+        MvcResult mvcResult1 = mockMvc.perform(post("/api/security/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(credentials1.toString()))
+                .andExpect(status().isOk())
+                .andReturn();
+        JsonNode jsonNode1 = objectMapper.readTree(mvcResult1.getResponse().getContentAsString());
+        tenant1AuthToken = "Bearer " + jsonNode1.get("accessToken").asText();
+
+        JSONObject credentials2 = new JSONObject();
+        credentials2.put("username", "user4@test.com");
+        credentials2.put("password", "pass");
+
+        MvcResult mvcResult2 = mockMvc.perform(post("/api/security/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(credentials2.toString()))
+                .andExpect(status().isOk())
+                .andReturn();
+        JsonNode jsonNode2 = objectMapper.readTree(mvcResult2.getResponse().getContentAsString());
+        tenant2AuthToken = "Bearer " + jsonNode2.get("accessToken").asText();
+    }
+
+    @Test
+    @Order(5)
+    void createEmployeeAsyncForTenant1() throws Exception {
+        JSONObject employee = new JSONObject();
+        employee.put("name", "Async Employee 1");
+
+        mockMvc.perform(post("/api/employees/async")
+                        .header(HttpHeaders.AUTHORIZATION, tenant1AuthToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(employee.toString()))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @Order(6)
+    void createEmployeeAsyncForTenant2() throws Exception {
+        JSONObject employee = new JSONObject();
+        employee.put("name", "Async Employee 2");
+
+        mockMvc.perform(post("/api/employees/async")
+                        .header(HttpHeaders.AUTHORIZATION, tenant2AuthToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(employee.toString()))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @Order(7)
+    void verifyDataIsolation() throws Exception {
+        // Verifying as tenant1
+        mockMvc.perform(get("/api/employees")
+                        .header(HttpHeaders.AUTHORIZATION, tenant1AuthToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(1))
+                .andExpect(jsonPath("$[0].name").value("Async Employee 1"));
+
+        // Verifying as tenant2
+        mockMvc.perform(get("/api/employees")
+                        .header(HttpHeaders.AUTHORIZATION, tenant2AuthToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(1))
+                .andExpect(jsonPath("$[0].name").value("Async Employee 2"));
+    }
+
+    private TenantConfig createTenantConfig(String tenantId) {
+        TenantConfig config = new TenantConfig();
+        config.setTenantId(tenantId);
+        config.setUrl("jdbc:h2:mem:" + tenantId + ";DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;DATABASE_TO_UPPER=FALSE");
+        config.setUsername("sa");
+        config.setPassword("");
+        return config;
+    }
+
+    @AfterAll
+    static void cleanup() {
+        tenantConfigRepository.deleteByTenantId("tenant3");
+        tenantConfigRepository.deleteByTenantId("tenant4");
+        appUserRepository.deleteByTenantId("tenant3");
+        appUserRepository.deleteByTenantId("tenant4");
+    }
+}


### PR DESCRIPTION
This commit introduces an asynchronous task to the multi-tenant application and ensures that the tenant context is correctly propagated and cleaned up.

- Enabled asynchronous processing with `@EnableAsync`.
- Configured a `ThreadPoolTaskExecutor` for async tasks.
- Implemented a `TenantAwareTaskDecorator` to propagate the tenant ID from the request thread to the async thread using `TenantContext`. The decorator also ensures the `ThreadLocal` context is cleared after the task completes to prevent tenant ID leakage.
- Created an `AsyncService` with an `@Async` method to save an `Employee` entity, demonstrating the tenant-aware database operation in a separate thread.
- Added a new endpoint `/api/employees/async` to the `EmployeeController` to trigger the async task.
- Added a new integration test class, `AsyncTenantContextTest`, to verify that the async tenant context propagation works correctly and maintains data isolation.
- Added `deleteByTenantId` methods to `AppUserRepository` and `TenantConfigRepository` to facilitate test data cleanup.